### PR TITLE
Add support to open commit from file blame view

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,6 +98,38 @@ async function openInBrowser(uri?: vscode.Uri): Promise<void> {
 		throw new Error('No file selected or active');
 	}
 
+	// Handle git:// URIs from Blame view
+	const blameInfo = parseGitBlameUri(fileUri);
+	if (blameInfo) {
+		const realFileUri = vscode.Uri.file(blameInfo.fsPath);
+		const workspaceFolder = vscode.workspace.getWorkspaceFolder(realFileUri);
+		if (!workspaceFolder) {
+			throw new Error('File is not in a workspace');
+		}
+
+		const gitInfo = await getGitInfo(workspaceFolder.uri.fsPath);
+		if (!gitInfo) {
+			throw new Error('Not a git repository or unable to determine remote URL');
+		}
+
+		const relativePath = path.relative(workspaceFolder.uri.fsPath, blameInfo.fsPath);
+
+		let startLine: number | null = null;
+		let endLine: number | null = null;
+		if (activeEditor && activeEditor.document.uri.toString() === fileUri.toString()) {
+			const selectedRange = getSelectedLineRange(activeEditor);
+			if (selectedRange) {
+				startLine = selectedRange.startLine;
+				endLine = selectedRange.endLine;
+			}
+		}
+
+		const url = buildUrl(gitInfo, relativePath, blameInfo.commitHash, startLine, endLine);
+		await vscode.env.openExternal(vscode.Uri.parse(url));
+		vscode.window.showInformationMessage(`Opened in browser: ${url}`);
+		return;
+	}
+
 	// Get workspace folder
 	const workspaceFolder = vscode.workspace.getWorkspaceFolder(fileUri);
 	if (!workspaceFolder) {
@@ -144,6 +176,31 @@ async function getGitInfo(workspacePath: string): Promise<GitRemoteInfo | null> 
 		return parseGitRemoteUrl(remoteUrl);
 	} catch (error) {
 		console.error('Error getting git remote URL:', error);
+		return null;
+	}
+}
+
+interface GitBlameUriInfo {
+	commitHash: string;
+	fsPath: string;
+}
+
+export function parseGitBlameUri(uri: vscode.Uri): GitBlameUriInfo | null {
+	if (uri.scheme !== 'git') {
+		return null;
+	}
+
+	try {
+		const query = JSON.parse(uri.query) as { path?: string; ref?: string };
+		const commitHash = query.ref;
+		const fsPath = query.path;
+
+		if (!commitHash || !fsPath) {
+			return null;
+		}
+
+		return { commitHash, fsPath };
+	} catch {
 		return null;
 	}
 }

--- a/src/test/git-url-parsing.test.ts
+++ b/src/test/git-url-parsing.test.ts
@@ -1,8 +1,44 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { buildUrl, getOwnerBasename, parseGitRemoteUrl } from '../extension';
+import { buildUrl, getOwnerBasename, parseGitBlameUri, parseGitRemoteUrl } from '../extension';
 
-// Test Git URL parsing functionality
+suite('Git Blame URI Tests', () => {
+	test('Returns commit hash and fsPath for a valid git:// URI', () => {
+		const query = JSON.stringify({ path: '/home/user/project/src/index.ts', ref: 'abc1234def5678' });
+		const uri = vscode.Uri.from({ scheme: 'git', path: '/home/user/project/src/index.ts.git', query });
+		const result = parseGitBlameUri(uri);
+		assert.ok(result);
+		assert.strictEqual(result.commitHash, 'abc1234def5678');
+		assert.strictEqual(result.fsPath, '/home/user/project/src/index.ts');
+	});
+
+	test('Returns null for a regular file:// URI', () => {
+		const uri = vscode.Uri.file('/home/user/project/src/index.ts');
+		const result = parseGitBlameUri(uri);
+		assert.strictEqual(result, null);
+	});
+
+	test('Returns null when ref is empty (uncommitted working-tree entry)', () => {
+		const query = JSON.stringify({ path: '/home/user/project/src/index.ts', ref: '' });
+		const uri = vscode.Uri.from({ scheme: 'git', path: '/home/user/project/src/index.ts.git', query });
+		const result = parseGitBlameUri(uri);
+		assert.strictEqual(result, null);
+	});
+
+	test('Returns null when ref is missing from query', () => {
+		const query = JSON.stringify({ path: '/home/user/project/src/index.ts' });
+		const uri = vscode.Uri.from({ scheme: 'git', path: '/home/user/project/src/index.ts.git', query });
+		const result = parseGitBlameUri(uri);
+		assert.strictEqual(result, null);
+	});
+
+	test('Returns null when query is not valid JSON', () => {
+		const uri = vscode.Uri.from({ scheme: 'git', path: '/some/file.ts', query: 'not-json' });
+		const result = parseGitBlameUri(uri);
+		assert.strictEqual(result, null);
+	});
+});
+
 suite('Git URL Parsing Tests', () => {
 	test('Parse HTTPS GitHub URL', () => {
 		const result = parseGitRemoteUrl('https://github.com/microsoft/vscode.git');


### PR DESCRIPTION
## Context

When the active editor is a Git Blame view, the document URI uses the git:// scheme with the commit hash encoded in the query string instead of pointing to a file on disk. The command previously failed in this context.

This PR adds parseGitBlameUri() to extract the commit hash and real file path from these URIs. When a Blame view is detected, the commit hash is used in place of the current branch to build the URL — all existing providers work unchanged since they use the same {branch} placeholder.